### PR TITLE
Typo Fix

### DIFF
--- a/Public/Get/Entities/Get-NinjaRMMDevices.ps1
+++ b/Public/Get/Entities/Get-NinjaRMMDevices.ps1
@@ -55,7 +55,7 @@ function Get-NinjaRMMDevices {
             $Resource = "v2/device/$($deviceID)"
         } elseif ($organisationID) {
             Write-Verbose 'Getting organisation from NinjaRMM API.'
-            $Organisation = Get-NinjaRMMOrganisation -organisationID $organisationID -ErrorAction SilentlyContinue
+            $Organisation = Get-NinjaRMMOrganisations -organisationID $organisationID -ErrorAction SilentlyContinue
             if ($Organisation) {
                 Write-Verbose "Retrieving devices for $($Organisation.Name)."
                 $Resource = "v2/organization/$($organisationID)/devices"


### PR DESCRIPTION
The singular spelling of Get-NinjaRMMOrganisations does not exist, which causes Get-NinjaRMMDevices to fail when specifying the -organisationID parameter.